### PR TITLE
🛡️ Sentinel: Add HTTP security headers

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,4 +1,4 @@
-## 2025-05-15 - Security Headers Implementation
+## 2026-05-12 - Security Headers Implementation
 **Vulnerability:** Missing HTTP security headers (CSP, X-Frame-Options, X-Content-Type-Options, etc.).
 **Learning:** For static Astro sites on Cloudflare Pages, security headers are best managed via a `public/_headers` file. The CSP must explicitly whitelist `static.cloudflareinsights.com` and `cloudflareinsights.com` to support the production analytics integration without compromising the restrictive `default-src 'none'` policy.
 **Prevention:** Always verify that third-party integrations (like analytics or fonts) are accounted for in the CSP to prevent breakage during production deployment.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - Security Headers Implementation
+**Vulnerability:** Missing HTTP security headers (CSP, X-Frame-Options, X-Content-Type-Options, etc.).
+**Learning:** For static Astro sites on Cloudflare Pages, security headers are best managed via a `public/_headers` file. The CSP must explicitly whitelist `static.cloudflareinsights.com` and `cloudflareinsights.com` to support the production analytics integration without compromising the restrictive `default-src 'none'` policy.
+**Prevention:** Always verify that third-party integrations (like analytics or fonts) are accounted for in the CSP to prevent breakage during production deployment.

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,6 @@
+/*
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=(), microphone=(), geolocation=(), interest-cohort=()
+  Content-Security-Policy: default-src 'none'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://cloudflareinsights.com; font-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;


### PR DESCRIPTION
### 🛡️ Sentinel Security Enhancement

🚨 **Severity:** MEDIUM (Security Enhancement / Defense in Depth)

💡 **Vulnerability:** The application was missing critical HTTP security headers, including Content-Security-Policy (CSP), X-Frame-Options, and X-Content-Type-Options.

🎯 **Impact:** Without these headers, the application was more susceptible to clickjacking, MIME-type sniffing, and cross-site scripting (XSS) attacks. Additionally, the lack of a Permissions-Policy meant the browser's default permissions for sensitive features (like camera and microphone) were not explicitly restricted.

🔧 **Fix:** 
- Created a `public/_headers` file, which Cloudflare Pages automatically uses to set response headers.
- Implemented a restrictive `Content-Security-Policy` with a `default-src 'none'` baseline.
- Whitelisted `static.cloudflareinsights.com` and `cloudflareinsights.com` in the CSP to maintain compatibility with the existing production analytics integration.
- Added `X-Frame-Options: DENY` to prevent clickjacking.
- Added `X-Content-Type-Options: nosniff` to prevent MIME-sniffing.
- Added `Referrer-Policy: strict-origin-when-cross-origin`.
- Added `Permissions-Policy` to disable unused browser features (camera, microphone, geolocation).

✅ **Verification:**
- Successfully ran `bun run build` and confirmed that `dist/_headers` exists and contains the expected configuration.
- Verified that `bun run check:ci` passes without issues.
- Confirmed that the CSP correctly accounts for the `import.meta.env.PUBLIC_CLOUDFLARE_WEB_ANALYTICS_TOKEN` integration found in `BaseLayout.astro`.

---
*PR created automatically by Jules for task [17899019876441809127](https://jules.google.com/task/17899019876441809127) started by @DeVlaminckDuncan*