### PR TITLE
🎨 Palette: improve accessibility for links opening in new tabs

### DIFF
--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -26,6 +26,8 @@ const safeRel =
         .filter(Boolean)
         .join(' ')
     : rel;
+
+const isExternal = target === '_blank';
 ---
 
 <a
@@ -38,6 +40,7 @@ const safeRel =
   {...rest}
 >
   <slot />
+  {isExternal && <span class="sr-only"> (opens in new tab)</span>}
 </a>
 
 <style>

--- a/src/components/TextLink.astro
+++ b/src/components/TextLink.astro
@@ -15,6 +15,8 @@ const safeRel =
         .filter(Boolean)
         .join(' ')
     : rel;
+
+const isExternal = target === '_blank';
 ---
 
 <a
@@ -24,7 +26,7 @@ const safeRel =
   rel={safeRel}
   aria-label={ariaLabel}
 >
-  <slot />
+  <slot />{isExternal && <span class="sr-only"> (opens in new tab)</span>}
 </a>
 
 <style>

--- a/src/pages/projects/[id].astro
+++ b/src/pages/projects/[id].astro
@@ -82,7 +82,7 @@ const structuredData = createJsonLdGraph([
           {links.map((link) => (
             <li>
               <a href={link.href} target="_blank" rel="noopener noreferrer">
-                {link.label}
+                {link.label}<span class="sr-only"> (opens in new tab)</span>
               </a>
             </li>
           ))}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -136,3 +136,16 @@ p {
     --section-spacing: var(--space-12);
   }
 }
+
+/* Utility classes */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}


### PR DESCRIPTION
### 💡 What: The UX enhancement added
Added a visually hidden "(opens in new tab)" message to all external links using the `.sr-only` utility class.

### 🎯 Why: The user problem it solves
Screen reader users are often unaware when a link opens in a new tab, which can lead to confusion when the back button doesn't work as expected or their focus is suddenly shifted. This change provides that necessary context.

### ♿ Accessibility: Any a11y improvements made
- Implemented standard `.sr-only` utility class.
- Added descriptive context for all `target="_blank"` links.
- Verified that the text is present in the DOM but hidden visually using Playwright assertions.

---
*PR created automatically by Jules for task [4316524960073647869](https://jules.google.com/task/4316524960073647869) started by @DeVlaminckDuncan*